### PR TITLE
Install hooks

### DIFF
--- a/src/builders/hooks.rs
+++ b/src/builders/hooks.rs
@@ -1,0 +1,101 @@
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+
+const PRE_COMMIT_HOOK: &str = r#"#!/bin/sh
+# Git Selective Ignore - Pre-commit Hook
+
+# Check if git-selective-ignore is available
+if ! command -v git-selective-ignore > /dev/null 2>&1; then
+    echo "Warning: git-selective-ignore not found in PATH"
+    exit 0
+fi
+
+# Process files before commit
+git-selective-ignore pre-commit
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to process selective ignore patterns"
+    exit 1
+fi
+"#;
+
+const POST_COMMIT_HOOK: &str = r#"#!/bin/sh
+# Git Selective Ignore - Post-commit Hook
+
+# Check if git-selective-ignore is available
+if ! command -v git-selective-ignore > /dev/null 2>&1; then
+    echo "Warning: git-selective-ignore not found in PATH"
+    exit 0
+fi
+
+# Restore files after commit
+git-selective-ignore post-commit
+"#;
+
+const POST_MERGE_HOOK: &str = r#"#!/bin/sh
+# Git Selective Ignore - Post-merge Hook
+
+# Check if git-selective-ignore is available
+if ! command -v git-selective-ignore > /dev/null 2>&1; then
+    echo "Warning: git-selective-ignore not found in PATH"
+    exit 0
+fi
+
+# Restore files after merge
+git-selective-ignore post-commit
+"#;
+
+const PRE_PUSH_HOOK: &str = r#"#!/bin/sh
+# Git Selective Ignore - Pre-push Hook
+
+# Check if git-selective-ignore is available
+if ! command -v git-selective-ignore > /dev/null 2>&1; then
+    echo "Warning: git-selective-ignore not found in PATH"
+    exit 0
+fi
+
+# Verify no ignored content is staged before pushing
+git-selective-ignore verify
+"#;
+pub fn install_git_hooks(repo_root: &Path) -> Result<()> {
+    let hooks_dir = repo_root.join(".git").join("hooks");
+    fs::create_dir_all(&hooks_dir)?;
+
+    install_hook(&hooks_dir, "pre-commit", PRE_COMMIT_HOOK)?;
+    install_hook(&hooks_dir, "post-commit", POST_COMMIT_HOOK)?;
+    install_hook(&hooks_dir, "post-merge", POST_MERGE_HOOK)?;
+    install_hook(&hooks_dir, "pre-push", PRE_PUSH_HOOK)?;
+
+    Ok(())
+}
+
+fn install_hook(hooks_dir: &Path, hook_name: &str, hook_content: &str) -> Result<()> {
+    let hook_path = hooks_dir.join(hook_name);
+
+    if hook_path.exists() {
+        // Check if it's already our hook
+        let existing_content = fs::read_to_string(&hook_path)?;
+        if existing_content.contains("Git Selective Ignore") {
+            println!("ℹ️  {hook_name} hook already installed");
+            return Ok(());
+        }
+
+        // Backup existing hook
+        let backup_path = hooks_dir.join(format!("{hook_name}.backup"));
+        fs::rename(&hook_path, backup_path)?;
+        println!("ℹ️  Backed up existing {hook_name} hook");
+    }
+
+    fs::write(&hook_path, hook_content)?;
+
+    // Make executable on Unix systems
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&hook_path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&hook_path, perms)?;
+    }
+
+    Ok(())
+}

--- a/src/builders/mod.rs
+++ b/src/builders/mod.rs
@@ -1,0 +1,1 @@
+pub mod hooks;

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GlobalSettings {
@@ -63,6 +63,10 @@ impl ConfigManager {
         let default_config = SelectiveIgnoreConfig::default();
         self.save_config(&default_config)?;
         Ok(())
+    }
+
+    pub fn get_repo_root(&self) -> &Path {
+        &self.repo_root
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,11 @@
-/// The Big IDEA:
-/// Idea is very simple, why can't I tell git to ignore
-/// some specific lines from my code base.
-/// Gitignore ignores the whole file but that not what I need
-///  it to ignore any line, block of code, line numbers
-/// etc. I don't want to accidentally commit something in the
-/// Git History which is not suppose to be there.
-/// I am also not interested to keep track of what all the changes
-/// I did to test it locally and now when I am ready to push
-/// I have to remove those not-required-in-git history stuff
 use anyhow::{Result};
 use clap::{Parser, Subcommand};
+use crate::core::config::ConfigManager;
+use crate::utils::install_hooks;
+
 mod core;
 mod utils;
+mod builders;
 
 #[derive(Parser)]
 #[command(name = "git-selective-ignore")]
@@ -25,12 +19,21 @@ struct Cli {
 enum Commands {
     /// Initialize selective ignore for this repository
     Init,
+    /// Install git hooks for automatic processing
+    InstallHooks,
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
+    // Validate config for all commands except `init` and `install-hooks`
+    if !matches!(cli.command, Commands::Init | Commands::InstallHooks) {
+        let config_manager = ConfigManager::new()?;
+        println!("Initializing...");
+    }
+
     match cli.command {
         Commands::Init => utils::initialize_repository(),
+        Commands::InstallHooks => install_hooks(),
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 use crate::core::config::ConfigManager;
 use anyhow::Result;
+use crate::builders::hooks;
 
 pub fn initialize_repository() -> Result<()> {
     let config_manager = ConfigManager::new()?;
@@ -7,4 +8,16 @@ pub fn initialize_repository() -> Result<()> {
     println!("✓ Initialized selective ignore for this repository");
     println!("Run 'git-selective-ignore install-hooks' to enable automatic processing");
     Ok(())
+}
+
+pub fn install_hooks() -> Result<()> {
+    let config_manager = get_config_manager()?;
+    hooks::install_git_hooks(&config_manager.get_repo_root())?;
+    println!("✓ Installed Git hooks for automatic processing");
+    Ok(())
+}
+
+// Helper function to create ConfigManager instance
+fn get_config_manager() -> Result<ConfigManager> {
+    ConfigManager::new()
 }


### PR DESCRIPTION
## Added `install-hooks` command

- Used to install the hooks
  - `pre-commit`
  - `post-commit`
- Generates the `git` hooks in `.git/hooks` folder like below
   ```
   # Git Selective Ignore - Pre-commit Hook

   # Check if git-selective-ignore is available
   if ! command -v git-selective-ignore > /dev/null 2>&1; then
      echo "Warning: git-selective-ignore not found in PATH"
      exit 0
   fi

   # Process files before commit
   git-selective-ignore pre-commit
   if [ $? -ne 0 ]; then
      echo "Error: Failed to process selective ignore patterns"
      exit 1
   fi
   ```