### PR TITLE
status-command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +116,20 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -141,6 +176,12 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "displaydoc"
@@ -201,6 +242,7 @@ name = "git-selective-ignore"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "git2",
  "regex",
@@ -238,6 +280,30 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -457,6 +523,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -869,10 +944,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2024"
 # Cargo automatically downloads, compiles, and links these dependencies for you.
 [dependencies]
 anyhow = "1.0.99"
+chrono = "0.4.41"
 clap = { version = "4.5.41", features = ["derive"] }
 git2 = "0.20.2"
 regex = "1.11.1"

--- a/src/builders/mod.rs
+++ b/src/builders/mod.rs
@@ -1,3 +1,4 @@
 pub mod hooks;
 pub mod patterns;
 pub mod storage;
+pub mod reporter;

--- a/src/builders/reporter.rs
+++ b/src/builders/reporter.rs
@@ -1,0 +1,165 @@
+use anyhow::Result;
+use std::collections::HashMap;
+
+use crate::builders::patterns::IgnorePattern;
+use crate::core::config::SelectiveIgnoreConfig;
+
+/// A struct that holds the status summary for a single file.
+///
+/// This provides a clean way to pass file-specific data from the `IgnoreEngine`
+/// to the `StatusReporter`.
+#[derive(Debug)]
+pub struct FileStatus {
+    /// Indicates whether the file exists in the filesystem.
+    pub exists: bool,
+    /// A flag indicating if the file contains lines that would be ignored by a pattern.
+    pub has_ignored_lines: bool,
+    /// The number of lines that match an ignore pattern.
+    pub ignored_line_count: usize,
+    /// The total number of lines in the file.
+    pub total_lines: usize,
+}
+
+pub trait StatusReporter {
+    fn generate_status_report(
+        &self,
+        config: &SelectiveIgnoreConfig,
+        file_statuses: HashMap<String, FileStatus>,
+    ) -> Result<()>;
+}
+
+/// A concrete implementation of `StatusReporter` that prints the report to the console.
+///
+/// This is the primary reporter used by the `show-status` command.
+pub struct ConsoleReporter;
+
+impl ConsoleReporter {
+    /// Constructs a new `ConsoleReporter` instance.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// A private helper function to format the status message for a single file.
+    ///
+    /// This function generates a human-readable string with icons, file path,
+    /// and a summary of the ignored lines.
+    ///
+    /// # Arguments
+    /// * `file_path`: The path to the file.
+    /// * `status`: A reference to the `FileStatus` struct for this file.
+    /// * `patterns`: A slice of `IgnorePattern`s configured for this file.
+    ///
+    /// # Returns
+    /// A `String` containing the formatted status report line.
+    fn format_file_status(
+        &self,
+        file_path: &str,
+        status: &FileStatus,
+        patterns: &[IgnorePattern],
+    ) -> String {
+        // Determine the appropriate emoji icon based on the file's status.
+        // 🔴: File does not exist.
+        // 🟡: File exists and has ignored lines.
+        // 🟢: File exists but has no ignored lines.
+        let status_icon = if status.exists {
+            if status.has_ignored_lines {
+                "🟡"
+            } else {
+                "🟢"
+            }
+        } else {
+            "🔴"
+        };
+
+        // Calculate the percentage of ignored lines, handling the case of a zero-line file.
+        let percentage = if status.total_lines > 0 {
+            (status.ignored_line_count as f64 / status.total_lines as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        // Format the final output string.
+        format!(
+            "{} {} ({} patterns, {}/{} lines ignored, {:.1}%)",
+            status_icon,
+            file_path,
+            patterns.len(),
+            status.ignored_line_count,
+            status.total_lines,
+            percentage
+        )
+    }
+}
+
+/// Implementation of the `StatusReporter` trait for `ConsoleReporter`.
+impl StatusReporter for ConsoleReporter {
+    /// Generates and prints the full status report to the standard output.
+    fn generate_status_report(
+        &self,
+        config: &SelectiveIgnoreConfig,
+        file_statuses: HashMap<String, FileStatus>,
+    ) -> Result<()> {
+        println!("📊 Git Selective Ignore Status Report");
+        println!("=====================================");
+
+        // If no files are configured, print a simple message and exit.
+        if config.files.is_empty() {
+            println!("No files configured for selective ignore.");
+            return Ok(());
+        }
+
+        // Initialize counters for the summary section.
+        let mut total_patterns = 0;
+        let mut total_ignored_lines = 0;
+        let mut files_with_issues = 0;
+
+        // Iterate through each file specified in the configuration.
+        for (file_path, patterns) in &config.files {
+            total_patterns += patterns.len();
+
+            // Look up the file's status from the HashMap provided by the `IgnoreEngine`.
+            if let Some(status) = file_statuses.get(file_path) {
+                total_ignored_lines += status.ignored_line_count;
+
+                // Increment the counter for files that don't exist in the working directory.
+                if !status.exists {
+                    files_with_issues += 1;
+                }
+
+                // Print the formatted status line for the current file.
+                println!("{}", self.format_file_status(file_path, status, patterns));
+
+                // If verbose mode is enabled, print the details of each pattern for the file.
+                if config.global_settings.verbose {
+                    for pattern in patterns {
+                        // The full ID is printed, but can be truncated for brevity if needed (commented out).
+                        println!(
+                            "  └─ {} ({}): {}",
+                            pattern.id,
+                            pattern.pattern_type,
+                            pattern.specification
+                        );
+                    }
+                }
+            } else {
+                // This case handles a scenario where a file is in the config but no
+                // status data was provided by the engine. This is an edge case.
+                println!("⚠️  {file_path} (status unknown)");
+            }
+        }
+
+        // Print the final summary section.
+        println!("\n📈 Summary:");
+        println!("  Total files: {}", config.files.len());
+        println!("  Total patterns: {total_patterns}");
+        println!("  Total ignored lines: {total_ignored_lines}");
+        println!("  Files with issues: {files_with_issues}");
+
+        // Provide a hint to the user if any files had issues (e.g., didn't exist).
+        if files_with_issues > 0 {
+            println!("\n⚠️  Run with --verbose to see detailed pattern information");
+        }
+
+        Ok(())
+    }
+}

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use crate::builders::storage::{BackupData, MemoryStorage, StorageProvider, TempFileStorage};
 use crate::builders::patterns::{IgnorePattern, PatternMatcher, PatternType};
+use crate::builders::reporter::{ConsoleReporter, FileStatus, StatusReporter};
 use crate::core::config::{BackupStrategy, ConfigManager, ConfigProvider};
 
 /// The `IgnoreEngine` is the central component responsible for managing the selective

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result};
 use clap::{Parser, Subcommand};
 use crate::core::config::ConfigManager;
-use crate::utils::{add_ignore_pattern, install_hooks, list_patterns, process_post_commit, process_pre_commit, remove_ignore_pattern, uninstall_hooks};
+use crate::utils::{add_ignore_pattern, install_hooks, list_patterns, process_post_commit, process_pre_commit, remove_ignore_pattern, show_status, uninstall_hooks};
 
 mod core;
 mod utils;
@@ -43,10 +43,11 @@ enum Commands {
     /// Restore files after commit (used by git hooks)
     PostCommit,
     /// Install git hooks for automatic processing
-    /// Install git hooks for automatic processing
     InstallHooks,
     /// Uninstall git hooks
     UninstallHooks,
+    /// Check status of ignored lines
+    Status,
 }
 
 fn main() -> Result<()> {
@@ -74,5 +75,6 @@ fn main() -> Result<()> {
         Commands::PostCommit => process_post_commit(),
         Commands::InstallHooks => install_hooks(),
         Commands::UninstallHooks => uninstall_hooks(),
+        Commands::Status => show_status(),
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -107,6 +107,16 @@ pub fn uninstall_hooks() -> Result<()> {
     Ok(())
 }
 
+/// Displays a status report for all configured files.
+///
+/// This command provides a summary of which files are configured, whether they exist,
+/// and how many lines would be ignored based on the current configuration.
+pub fn show_status() -> Result<()> {
+    let mut engine = get_engine()?;
+    engine.show_status()?;
+    Ok(())
+}
+
 /// A private helper function to create and return an `IgnoreEngine` instance.
 ///
 /// This function encapsulates the logic of initializing the `ConfigManager`


### PR DESCRIPTION
### Added `status` command

- `status` command reflects the status of the repository to the console
- Added `Reporter` module to handle `console` display and `status` identification