### PR TITLE
verify-command-and-validation-logic

### DIFF
--- a/src/builders/mod.rs
+++ b/src/builders/mod.rs
@@ -3,3 +3,4 @@ pub mod patterns;
 pub mod storage;
 pub mod reporter;
 pub mod importer;
+pub mod validator;

--- a/src/builders/validator.rs
+++ b/src/builders/validator.rs
@@ -1,0 +1,174 @@
+use anyhow::Result;
+use std::collections::HashSet;
+
+use crate::builders::patterns;
+use crate::core::config;
+
+/// The `ConfigValidator` trait defines the public interface for validating the
+/// selective ignore configuration.
+///
+/// This trait allows for the implementation of different validation strategies,
+/// such as a strict validator or a more permissive one, by adhering to a common
+/// set of methods.
+pub trait ConfigValidator {
+    /// Performs a full validation of the `SelectiveIgnoreConfig` and returns
+    /// a list of issues found.
+    ///
+    /// # Arguments
+    /// * `config`: The `SelectiveIgnoreConfig` to be validated.
+    ///
+    /// # Returns
+    /// A `Result<Vec<String>>` containing a vector of strings, where each string
+    /// describes a specific validation issue.
+    fn validate_config(&self, config: &config::SelectiveIgnoreConfig) -> Result<Vec<String>>;
+
+    /// Validates a single `IgnorePattern` and returns a list of issues.
+    ///
+    /// # Arguments
+    /// * `pattern`: The `IgnorePattern` to be validated.
+    ///
+    /// # Returns
+    /// A `Result<Vec<String>>` containing a vector of strings, each describing a
+    /// validation issue for the given pattern.
+    fn validate_pattern(&self, pattern: &patterns::IgnorePattern) -> Result<Vec<String>>;
+}
+
+/// The `StandardValidator` is a concrete implementation of `ConfigValidator`.
+///
+/// It performs a series of standard checks to ensure the configuration file
+/// is well-formed and does not contain potentially dangerous or conflicting
+/// patterns.
+pub struct StandardValidator;
+
+impl StandardValidator {
+    /// Creates a new instance of `StandardValidator`.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Checks if a file exists at a given path.
+    ///
+    /// This is a simple helper function used to verify that configured file
+    /// paths are valid in the current filesystem.
+    ///
+    /// # Arguments
+    /// * `file_path`: The path to the file to check.
+    ///
+    /// # Returns
+    /// `true` if the file exists, `false` otherwise.
+    fn check_file_exists(&self, file_path: &str) -> bool {
+        std::path::Path::new(file_path).exists()
+    }
+
+    /// Checks for conflicting patterns within a single file's configuration.
+    ///
+    /// This is an important check to prevent unintended behavior. For example,
+    /// it detects if multiple `LineNumber` patterns are defined for the same line.
+    /// This check can be extended to cover other types of conflicts in the future.
+    ///
+    /// # Arguments
+    /// * `patterns`: A slice of `IgnorePattern`s for a single file.
+    ///
+    /// # Returns
+    /// A `Vec<String>` containing warnings for any conflicts found.
+    fn check_pattern_conflicts(&self, patterns: &[patterns::IgnorePattern]) -> Vec<String> {
+        let mut warnings = Vec::new();
+        let mut line_numbers = HashSet::new();
+
+        for pattern in patterns {
+            match pattern.pattern_type {
+                patterns::PatternType::LineNumber => {
+                    if let Ok(line_num) = pattern.specification.parse::<usize>() {
+                        // Check if a pattern for this line number has already been seen.
+                        if line_numbers.contains(&line_num) {
+                            warnings.push(format!(
+                                "Duplicate line number pattern for line {}",
+                                line_num
+                            ));
+                        }
+                        line_numbers.insert(line_num);
+                    }
+                }
+                _ => {} // Other pattern types don't have this type of conflict yet.
+            }
+        }
+        warnings
+    }
+}
+
+impl ConfigValidator for StandardValidator {
+    /// The main public method for validating the entire configuration.
+    ///
+    /// It orchestrates multiple checks, including:
+    /// - Version compatibility.
+    /// - Whether each configured file exists.
+    /// - Conflicts between patterns within the same file.
+    /// - The validity of each individual pattern's specification.
+    fn validate_config(&self, config: &config::SelectiveIgnoreConfig) -> Result<Vec<String>> {
+        let mut issues = Vec::new();
+
+        // Check for an unsupported configuration version.
+        if config.version != "1.0" {
+            issues.push(format!("Unsupported config version: {}", config.version));
+        }
+
+        // Iterate through each file and its patterns for validation.
+        for (file_path, patterns) in &config.files {
+            if !self.check_file_exists(file_path) {
+                issues.push(format!("File not found: {file_path}"));
+            }
+
+            // Check for pattern conflicts within the file's patterns.
+            let conflicts = self.check_pattern_conflicts(patterns);
+            issues.extend(conflicts);
+
+            // Validate each pattern's syntax and semantics.
+            for pattern in patterns {
+                let pattern_issues = self.validate_pattern(pattern)?;
+                issues.extend(pattern_issues);
+            }
+        }
+
+        Ok(issues)
+    }
+
+    /// Validates a single pattern's syntax and checks for problematic configurations.
+    ///
+    /// This function performs two levels of validation:
+    /// 1. **Syntax Validation:** It calls the pattern's own `validate()` method
+    ///    to check if its `specification` string is well-formed (e.g., a valid
+    ///    regex or integer).
+    /// 2. **Semantic Validation:** It checks for specific patterns that, while
+    ///    syntactically correct, might be a mistake (e.g., an empty regex or a
+    ///    pattern that matches everything).
+    fn validate_pattern(&self, pattern: &patterns::IgnorePattern) -> Result<Vec<String>> {
+        let mut issues = Vec::new();
+
+        // Perform the pattern's own validation, which checks for correct syntax.
+        if let Err(e) = pattern.validate() {
+            issues.push(format!("Invalid pattern {}: {}", pattern.id, e));
+        }
+
+        // Check for patterns that are syntactically valid but semantically problematic.
+        match pattern.pattern_type {
+            patterns::PatternType::LineRegex => {
+                if pattern.specification.is_empty() {
+                    issues.push("Empty regex pattern will match nothing".to_string());
+                }
+                if pattern.specification == ".*" {
+                    issues.push("Pattern '.*' will match all lines".to_string());
+                }
+            }
+            patterns::PatternType::LineNumber => {
+                if let Ok(line_num) = pattern.specification.parse::<usize>() {
+                    if line_num == 0 {
+                        issues.push("Line numbers start from 1, not 0".to_string());
+                    }
+                }
+            }
+            _ => {} // No specific semantic checks for other pattern types yet.
+        }
+
+        Ok(issues)
+    }
+}

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use crate::builders::importer::{FileImporter, PatternImporter};
 use crate::builders::patterns::IgnorePattern;
+use crate::builders::validator::{ConfigValidator, StandardValidator};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GlobalSettings {
@@ -65,6 +66,23 @@ impl ConfigManager {
         let default_config = SelectiveIgnoreConfig::default();
         self.save_config(&default_config)?;
         Ok(())
+    }
+
+    pub fn validate_config(&self) -> Result<()> {
+        let config = self.load_config()?;
+        let validator = StandardValidator::new();
+        let issues = validator.validate_config(&config)?;
+
+        if issues.is_empty() {
+            println!("✓ Configuration is valid.");
+            Ok(())
+        } else {
+            println!("⚠️  Found issues in configuration:");
+            for issue in issues {
+                println!("  - {issue}");
+            }
+            anyhow::bail!("Configuration validation failed.");
+        }
     }
 
     pub fn add_pattern(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result};
 use clap::{Parser, Subcommand};
 use crate::core::config::ConfigManager;
-use crate::utils::{add_ignore_pattern, export_patterns, import_patterns, install_hooks, list_patterns, process_post_commit, process_pre_commit, remove_ignore_pattern, show_status, uninstall_hooks};
+use crate::utils::{add_ignore_pattern, export_patterns, import_patterns, install_hooks, list_patterns, process_post_commit, process_pre_commit, remove_ignore_pattern, show_status, uninstall_hooks, verify_staging_area};
 
 mod core;
 mod utils;
@@ -48,6 +48,8 @@ enum Commands {
     UninstallHooks,
     /// Check status of ignored lines
     Status,
+    /// Verify no ignored content is in staging area
+    Verify,
     /// Import patterns from existing tools (.gitignore style)
     Import {
         /// Import from file path
@@ -72,7 +74,7 @@ fn main() -> Result<()> {
     // Validate config for all commands except `init` and `install-hooks`
     if !matches!(cli.command, Commands::Init | Commands::InstallHooks) {
         let config_manager = ConfigManager::new()?;
-        println!("Initializing...");
+        config_manager.validate_config()?;
     }
 
     match cli.command {
@@ -92,6 +94,7 @@ fn main() -> Result<()> {
         Commands::InstallHooks => install_hooks(),
         Commands::UninstallHooks => uninstall_hooks(),
         Commands::Status => show_status(),
+        Commands::Verify => verify_staging_area(),
         Commands::Import {
             file_path,
             import_type,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -117,6 +117,16 @@ pub fn show_status() -> Result<()> {
     Ok(())
 }
 
+/// Verifies that no ignored content is present in the staging area.
+///
+/// This can be used as a stricter pre-commit check that fails if any ignored
+/// content is detected, rather than automatically removing it.
+pub fn verify_staging_area() -> Result<()> {
+    let mut engine = get_engine()?;
+    engine.verify_staging()?;
+    Ok(())
+}
+
 /// Imports patterns from an external file into the selective ignore configuration.
 ///
 /// This allows users to share and reuse patterns between different projects.


### PR DESCRIPTION
### Added `verify` command and `validation` logic

- `verify` command will verify the staging
- `validation` logic is used to check the configuration validation before any command
- `validation` is at the entrypoint to validate except `init` and `install_hook`